### PR TITLE
Image types; Att&ck data updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,4 +43,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run the tests
       run: |
-        python -m unittest tests/threadtests.py
+        python -m unittest discover tests/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Configuration defaults can be changed [here](https://github.com/arachne-threat-i
 
 You are also welcome to check our test-suite via:
 ```
-python -m unittest tests/threadtests.py
+python -m unittest discover tests/
 ```
 
 ## Shared vs. Local

--- a/main.py
+++ b/main.py
@@ -40,11 +40,11 @@ async def background_tasks(taxii_local=ONLINE_BUILD_SOURCE, build=False, json_fi
         await data_svc.reload_database()
         if taxii_local == ONLINE_BUILD_SOURCE:
             try:
-                await data_svc.insert_attack_data()
+                await rest_svc.insert_attack_data()
             except Exception as exc:
                 logging.critical('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
-                                 'COULD NOT CONNECT TO TAXII SERVERS: {}\nPLEASE UTILIZE THE OFFLINE CAPABILITY FLAG '
-                                 '"-FF" FOR OFFLINE DATABASE BUILDING\n'
+                                 'COULD NOT CONNECT TO TAXII SERVERS: {}\nPLEASE UPDATE CONFIG `taxii-local` '
+                                 'FOR OFFLINE DATABASE BUILDING\n'
                                  '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'.format(exc))
                 sys.exit()
         elif taxii_local == OFFLINE_BUILD_SOURCE and json_file:
@@ -124,7 +124,7 @@ def main(directory_prefix='', route_prefix=None, app_setup_func=None):
         conf_build = config.get('build', True)
         host = config.get('host', '0.0.0.0')
         port = config.get('port', 9999)
-        taxii_local = config.get('taxii-local', 'taxii-server')
+        taxii_local = config.get('taxii-local', ONLINE_BUILD_SOURCE)
         js_src = config.get('js-libraries', 'js-online-src')
         max_tasks = config.get('max-analysis-tasks', 1)
         queue_limit = config.get('queue_limit', 0)

--- a/main.py
+++ b/main.py
@@ -164,6 +164,8 @@ def main(directory_prefix='', route_prefix=None, app_setup_func=None):
         max_tasks = config.get('max-analysis-tasks', 1)
         queue_limit = config.get('queue_limit', 0)
         json_file = config.get('json_file', None)
+        update_json_file = config.get('update_json_file', False)
+        json_file_indent = config.get('json_file_indent', 2)
         json_file_path = os.path.join(dir_prefix, 'threadcomponents', 'models', json_file) if json_file else None
         attack_dict = None
     # Set the attack dictionary filepath if applicable
@@ -185,6 +187,10 @@ def main(directory_prefix='', route_prefix=None, app_setup_func=None):
         int(port)
     except ValueError:
         raise ValueError(int_error % 'port')
+    try:
+        int(json_file_indent)
+    except ValueError:
+        raise ValueError(int_error % 'json_file_indent')
     # Determine DB engine to use
     db_obj = None
     if db_conf == DB_SQLITE:
@@ -201,8 +207,9 @@ def main(directory_prefix='', route_prefix=None, app_setup_func=None):
     reg_svc = RegService(dao=dao)
     data_svc = DataService(dao=dao, web_svc=web_svc, dir_prefix=dir_prefix)
     ml_svc = MLService(web_svc=web_svc, dao=dao, dir_prefix=dir_prefix)
+    attack_file_settings = dict(filepath=json_file_path, update=update_json_file, indent=json_file_indent)
     rest_svc = RestService(web_svc, reg_svc, data_svc, ml_svc, dao, dir_prefix=dir_prefix, queue_limit=queue_limit,
-                           max_tasks=max_tasks)
+                           max_tasks=max_tasks, attack_file_settings=attack_file_settings)
     services = dict(dao=dao, data_svc=data_svc, ml_svc=ml_svc, reg_svc=reg_svc, web_svc=web_svc, rest_svc=rest_svc)
     website_handler = WebAPI(services=services, js_src=js_src)
     start(host, port, taxii_local=taxii_local, build=conf_build, json_file=attack_dict, app_setup_func=app_setup_func)

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ async def background_tasks(taxii_local=ONLINE_BUILD_SOURCE, build=False, json_fi
         await data_svc.reload_database()
         if taxii_local == ONLINE_BUILD_SOURCE:
             try:
-                await data_svc.insert_attack_stix_data()
+                await data_svc.insert_attack_data()
             except Exception as exc:
                 logging.critical('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
                                  'COULD NOT CONNECT TO TAXII SERVERS: {}\nPLEASE UTILIZE THE OFFLINE CAPABILITY FLAG '

--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ async def update_attack_data_scheduler():
         return
     # Check if we are at the beginning of the month, if so, it's the right day for updates
     today = datetime.now()
-    if today.month != 1:
+    if today.day != 1:
         return
     # Pick a quiet/suitable time to do the update (early in the next morning)
     update_datetime = datetime(today.year, today.month, today.day + 1, 1, 0, 0)

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+SCHEMA_FILE = os.path.join('threadcomponents', 'conf', 'schema.sql')
+
 
 def delete_db_file(file_path):
     """Function to delete a local database test file."""

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -1,0 +1,11 @@
+import logging
+import os
+
+
+def delete_db_file(file_path):
+    """Function to delete a local database test file."""
+    if file_path and os.path.isfile(file_path):
+        os.remove(file_path)
+    else:
+        logging.warning('Test DB file %s could not be deleted; accumulated data in-between test runs expected.'
+                        % file_path)

--- a/tests/test_attack_data.py
+++ b/tests/test_attack_data.py
@@ -1,0 +1,43 @@
+import os
+
+from tests.thread_app_test import ThreadAppTest
+
+
+class TestAttackData(ThreadAppTest):
+    """A test suite for checking our handling of attack-data."""
+    DB_TEST_FILE = os.path.join('tests', 'threadtestattackdata.db')
+
+    async def test_attack_list(self):
+        """Function to test the attack list for the dropdown was created successfully."""
+        # For our test attack data, we predict 2 will not be sub attacks (no Txx.xx TID) and 1 will be
+        predicted = [dict(uid='d99999', name='Drain', tid='T1029', parent_tid=None, parent_name=None),
+                     dict(uid='f12345', name='Fire', tid='T1562', parent_tid=None, parent_name=None),
+                     dict(uid='f32451', name='Firaga', tid='T1562.004', parent_tid='T1562', parent_name='Fire')]
+        # The generated dropdown list to check against our prediction
+        result = self.web_api.attack_dropdown_list
+        for attack_dict in predicted:
+            self.assertTrue(attack_dict in result, msg='Attack %s was expected but not present.' % str(attack_dict))
+        # Check that inactive attacks are in the database but not in the dropdown list
+        inactive_attack_all = await self.db.get('attack_uids', equal=dict(inactive=1))
+        for inactive_attack in inactive_attack_all:
+            self.assertFalse(inactive_attack in result, msg='Inactive attack was found in dropdown list.')
+
+    async def test_update_attacks(self):
+        """Function to test when new attacks are added to the database."""
+        # Create a new attack to mock being added; confirm it is not already in the database
+        new_attack = dict(uid='b12345', description='Blizzard spell costing 4MP', tid='T1489', name='Blizzard')
+        attacks = await self.db.get('attack_uids')
+        if (new_attack in attacks) or (new_attack in self.web_api.attack_dropdown_list):
+            self.skipTest('Could not test added attacks as database has specified attack already.')
+        # Mock the retrieval of current Att%ck data to be this new attack and call the update method
+        self.mock_current_attack_data(attack_list=[new_attack])
+        await self.web_api.fetch_and_update_attack_data()
+        # Re-obtain the attacks in the database and check the new attack is in the db and dropdown-list
+        attacks = await self.db.get('attack_uids')
+        # Tweak original attack-dict to be how they would be in the db and dropdown-list before assertions
+        in_db = dict(new_attack, inactive=0)
+        in_dropdown_list = dict(new_attack, parent_tid=None, parent_name=None)
+        in_dropdown_list.pop('description')
+        self.assertTrue(in_db in attacks, 'New attack did not appear in database.')
+        self.assertTrue(in_dropdown_list in self.web_api.attack_dropdown_list,
+                        'New attack did not appear in web-dropdown-list.')

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sqlite3
 
-from tests.misc import delete_db_file
+from tests.misc import delete_db_file, SCHEMA_FILE
 from threadcomponents.database.thread_sqlite3 import ThreadSQLite
 from threadcomponents.service.rest_svc import ReportStatus, UID as UID_KEY
 from unittest import IsolatedAsyncioTestCase
@@ -17,8 +17,7 @@ class TestDBSQL(IsolatedAsyncioTestCase):
     def setUpClass(cls):
         """Any setting-up before all the test methods."""
         cls.db = ThreadSQLite(cls.DB_TEST_FILE)
-        schema_file = os.path.join('threadcomponents', 'conf', 'schema.sql')
-        with open(schema_file) as schema_opened:
+        with open(SCHEMA_FILE) as schema_opened:
             cls.schema = schema_opened.read()
         cls.backup_schema = cls.db.generate_copied_tables(cls.schema)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,248 @@
+import logging
+import os
+import sqlite3
+
+from tests.misc import delete_db_file
+from threadcomponents.database.thread_sqlite3 import ThreadSQLite
+from threadcomponents.service.rest_svc import ReportStatus, UID as UID_KEY
+from unittest import IsolatedAsyncioTestCase
+from uuid import UUID
+
+
+class TestDBSQL(IsolatedAsyncioTestCase):
+    """A test suite for checking our SQL-generating code."""
+    DB_TEST_FILE = os.path.join('tests', 'threadtestsql.db')
+
+    @classmethod
+    def setUpClass(cls):
+        """Any setting-up before all the test methods."""
+        cls.db = ThreadSQLite(cls.DB_TEST_FILE)
+        schema_file = os.path.join('threadcomponents', 'conf', 'schema.sql')
+        with open(schema_file) as schema_opened:
+            cls.schema = schema_opened.read()
+        cls.backup_schema = cls.db.generate_copied_tables(cls.schema)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Any tidying-up after all the test methods."""
+        # Delete the database so a new DB file is used in next test-run
+        delete_db_file(cls.DB_TEST_FILE)
+
+    async def asyncSetUp(self):
+        """Any setting-up before each test method."""
+        # Build the database (can't run in setUpClass() as this is an async method)
+        await self.db.build(self.schema)
+        await self.db.build(self.backup_schema)
+        await self.db.initialise_column_names()
+
+    async def check_data_appeared_in_table(self, table, method_name='unspecified', found_check=None, expect_found=True,
+                                           fail_msg='', **kwargs):
+        """
+        Function to check whether or not data is found in a table.
+        :param table: The table to check whether data has appeared.
+        :param method_name: The test method calling this method (for logging purposes).
+        :param found_check: The method to determine given a result from the database, if data is found.
+        :param expect_found: If we are checking data is found in the table or not.
+        :param fail_msg: The message to report on test failure.
+        **kwargs should match the kwargs of ThreadDB.get()
+        """
+        # If we don't have a way to do the check, fail this test
+        if not callable(found_check):
+            message = '%s: Not provided with method to check data is%s in table.' % \
+                      (method_name, '' if expect_found else ' not')
+            self.fail(message)
+        # Prefix failure message with test-method calling this method
+        fail_msg = '%s: %s' % (method_name, fail_msg if fail_msg else 'expected ' + str(expect_found))
+        # Obtain the sentences for the report and initialise a 'found' flag
+        results = await self.db.get(table, **kwargs)
+        found = False
+        # Check through the returned results to see if there is a match
+        for returned in results:
+            if found_check(returned):
+                found = True
+                break
+        # Check our expectations on whether the data is found or not
+        self.assertEqual(expect_found, found, msg=fail_msg)
+
+    async def test_build(self):
+        """Function to test the db built tables successfully."""
+        # SQLite-specific query to obtain table names
+        sql = 'SELECT name FROM %s WHERE type = \'table\';'
+        try:
+            results = await self.db.raw_select(sql % 'sqlite_schema', single_col=True)
+        except sqlite3.OperationalError:
+            # If the above fails, try the old name for the table for the lookup
+            try:
+                results = await self.db.raw_select(sql % 'sqlite_master', single_col=True)
+            except sqlite3.OperationalError:
+                # If this still fails, fail the test
+                self.fail('Unable to obtain table names from schema; raw_select() may be at fault.')
+        # The list of tables we are expecting to have been created
+        expected = ['attack_uids', 'reports', 'report_sentences', 'true_positives', 'true_negatives', 'false_positives',
+                    'false_negatives', 'regex_patterns', 'similar_words', 'report_sentence_hits', 'original_html',
+                    'report_sentences_initial', 'report_sentence_hits_initial', 'original_html_initial']
+        # Check the expectations against the results
+        for table in results:
+            self.assertTrue(table in expected, msg='Table %s was created but not expected.' % table)
+        for table in expected:
+            self.assertTrue(table in results, msg='Table %s was expected but not created.' % table)
+
+    async def test_insert(self):
+        """Function to test INSERT statements are generated correctly."""
+        # Test data to insert
+        data = dict(title='my_report', url='report.url', current_status=ReportStatus.QUEUE.value, token=None)
+        # Obtain the generated SQL
+        generated = await self.db.insert('reports', data, return_sql=True)
+        # The SQL we are expecting and the number of parameters we are expecting to be returned separately to the SQL
+        expected = 'INSERT INTO reports (title, url, current_status, token) VALUES (?, ?, ?, NULL)'
+        expected_params_len = 3
+        # Test expectations are correct
+        self.assertEqual(expected, generated[0], msg='SQL statement not generated as expected.')
+        self.assertEqual(expected_params_len, len(generated[1]), msg='SQL parameters not generated as expected.')
+
+    async def test_insert_with_uid(self):
+        """Function to test INSERT statements with generated UIDs are generated correctly."""
+        # Test data to insert
+        data = dict(title='my_report2', url='report2.url', current_status=ReportStatus.QUEUE.value, token=None)
+        # Obtain the generated SQL
+        generated = await self.db.insert_generate_uid('reports', data, return_sql=True)
+        # We are now expecting 4 parameters to be returned (as the UID has been generated)
+        expected_params_len = 4
+        # Test expectation is correct
+        self.assertEqual(expected_params_len, len(generated[1]), msg='SQL parameters not generated as expected.')
+        # Test valid UUID has been attached to the data; raises ValueError if invalid UUID
+        self.assertTrue(data[UID_KEY] in generated[1], msg='UID not passed to DB parameters.')
+        UUID(data[UID_KEY])
+
+    async def test_insert_then_update(self):
+        """Function to test inserted data can be updated successfully."""
+        # A small function to check given a report-record, that it matches with an initial title defined in this method
+        def pre_update_found(r):
+            return r.get('title') == initial_title and r.get(UID_KEY) == report_id
+
+        # A small function to check given a report-record, that it matches with an updated title defined in this method
+        def post_update_found(r):
+            return r.get('title') == new_title and r.get(UID_KEY) == report_id
+
+        # The test change we will be doing
+        initial_title = 'There and Back Again'
+        new_title = 'A Developer\'s Tale'
+        # Insert the report data
+        report = dict(title=initial_title, url='localhost.or.shire', current_status=ReportStatus.QUEUE.value)
+        report_id = await self.db.insert_generate_uid('reports', report)
+        # The kwargs for check_data_appeared_in_table() which are the same for all checks
+        checking_args = dict(method_name='test_insert_then_update', equal=dict(uid=report_id))
+        # Confirm the report got inserted
+        await self.check_data_appeared_in_table('reports', expect_found=True, found_check=pre_update_found,
+                                                fail_msg='inserted data not found', **checking_args)
+        # Confirm the new_title does not appear as a report title yet
+        rep_results = await self.db.get('reports', equal=dict(title=new_title))
+        if rep_results:
+            self.skipTest('Could not test updating table as tested updates already exist pre-update.')
+        # Update the report with the new title
+        await self.db.update('reports', where=dict(uid=report_id), data=dict(title=new_title))
+        # Confirm old report title is not found but new report title is found
+        await self.check_data_appeared_in_table('reports', expect_found=False, found_check=pre_update_found,
+                                                fail_msg='initial data found after update', **checking_args)
+        await self.check_data_appeared_in_table('reports', expect_found=True, found_check=post_update_found,
+                                                fail_msg='updated data not found', **checking_args)
+
+    async def test_insert_then_delete(self):
+        """Function to test inserted data can be deleted successfully."""
+        # A small function to check given a report-record, that it matches with a report ID defined in this method
+        def report_found(r):
+            return r.get(UID_KEY) == report_id
+
+        # Insert the report data
+        report = dict(title='Don\'t Stop Moving', url='funky.funky.beat', current_status=ReportStatus.QUEUE.value)
+        report_id = await self.db.insert_generate_uid('reports', report)
+        # The kwargs for check_data_appeared_in_table() which are the same for all checks
+        checking_args = dict(method_name='test_insert_then_delete', equal=dict(uid=report_id))
+        # Confirm the report got inserted
+        await self.check_data_appeared_in_table('reports', expect_found=True, found_check=report_found,
+                                                fail_msg='inserted data not found', **checking_args)
+        # Carry out the delete
+        await self.db.delete('reports', dict(uid=report_id))
+        # Confirm the report got deleted
+        await self.check_data_appeared_in_table('reports', expect_found=False, found_check=report_found,
+                                                fail_msg='deleted data was found', **checking_args)
+
+    async def test_select_with_no_args(self):
+        """Function to test behaviour of SELECT statements with no clauses specified."""
+        # Both calls should work without raising an error
+        await self.db.get('reports')
+        await self.db.get('reports', equal=None, not_equal=None, order_by_asc=None, order_by_desc=None)
+
+    async def test_insert_with_backup(self):
+        """Function to test inserting data with a backup works as expected."""
+        # A small function to check given a sentence-record, that it matches with the sentence defined in this method
+        def sentence_found(s):
+            return s.get('text') == sentence and s.get(UID_KEY) == sen_id
+        # Insert a report
+        report = dict(title='Return of the Phyrexian Obliterator', url='trampled.oops',
+                      current_status=ReportStatus.QUEUE.value)
+        report_id = await self.db.insert_generate_uid('reports', report)
+        # Confirm we have no sentences for this report yet
+        sen_results = await self.db.get('report_sentences', equal=dict(report_uid=report_id))
+        sen_results_backup = await self.db.get('report_sentences_initial', equal=dict(report_uid=report_id))
+        if sen_results or sen_results_backup:
+            self.skipTest('Could not test storing new data in backup tables as new data already exists.')
+
+        # Reports are not backed-up, so let's test a report-sentence which is backed up
+        sentence = 'Behold blessed perfection.'
+        data = dict(report_uid=report_id, text=sentence, html='<p>%s</p>' % sentence, sen_index=0,
+                    found_status=self.db.val_as_false)
+        sen_id = await self.db.insert_with_backup('report_sentences', data)
+        # The kwargs for check_data_appeared_in_table() which are the same for all checks
+        checking_args = dict(method_name='test_insert_with_backup', found_check=sentence_found,
+                             equal=dict(report_uid=report_id))
+        # After method is called, let's test both the report_sentences table and its back-up table have this sentence
+        for table in ['report_sentences', 'report_sentences_initial']:
+            error_msg = 'data missing in table %s after being inserted' % table
+            await self.check_data_appeared_in_table(table, expect_found=True, fail_msg=error_msg, **checking_args)
+        # Confirm deleting sentence in report_sentences does not delete the backup
+        await self.db.delete('report_sentences', dict(text=sentence))
+        await self.check_data_appeared_in_table(
+            'report_sentences', expect_found=False,
+            fail_msg='data deleted in report_sentences but found', **checking_args
+        )
+        await self.check_data_appeared_in_table(
+            'report_sentences_initial', expect_found=True,
+            fail_msg='data deleted in report_sentences and missing in report_sentences_initial', **checking_args
+        )
+
+    async def test_insert_with_no_data(self):
+        """Function to test behaviour of INSERT statements with no values specified."""
+        # TypeError where data to be inserted is None (not a dictionary)
+        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for report.'):
+            await self.db.insert('reports', None)
+        # ValueError where data to be inserted is (a dictionary but) empty
+        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for report.'):
+            await self.db.insert('reports', dict())
+
+    async def test_update_with_no_data(self):
+        """Function to test behaviour of UPDATE statements with no SET clause specified."""
+        # TypeError where data to be set is None (not a dictionary)
+        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for `data` parameter.'):
+            await self.db.update('reports', where=dict(title='Nothing is True'), data=None)
+        # ValueError where data to be set is (a dictionary but) empty
+        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for `data` parameter.'):
+            await self.db.update('reports', where=dict(title='Everything is Permitted; Except This'), data=dict())
+
+    async def test_update_with_no_where(self):
+        """Function to test behaviour of UPDATE statements with no WHERE clause specified."""
+        # TypeError where WHERE-clause data is None (not a dictionary)
+        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for `where` parameter.'):
+            await self.db.update('reports', where=None, data=dict(title='One title'))
+        # ValueError where WHERE-clause data is (a dictionary but) empty
+        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for `where` parameter.'):
+            await self.db.update('reports', where=dict(), data=dict(title='To Rule Them All'))
+
+    async def test_delete_with_no_where(self):
+        """Function to test behaviour of DELETE statements with no WHERE clause specified."""
+        # TypeError where WHERE-clause data is None (not a dictionary)
+        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for report.'):
+            await self.db.delete('reports', None)
+        # ValueError where WHERE-clause data is (a dictionary but) empty
+        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for report.'):
+            await self.db.delete('reports', dict())

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,7 +1,6 @@
 import aiohttp_jinja2
 import asyncio
 import jinja2
-import logging
 import os
 import random
 import sqlite3
@@ -9,6 +8,7 @@ import sqlite3
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase
 from contextlib import suppress
+from tests.misc import delete_db_file
 from threadcomponents.database.dao import Dao
 from threadcomponents.database.thread_sqlite3 import ThreadSQLite
 from threadcomponents.handlers.web_api import WebAPI
@@ -17,262 +17,13 @@ from threadcomponents.service.ml_svc import MLService
 from threadcomponents.service.reg_svc import RegService
 from threadcomponents.service.rest_svc import ReportStatus, RestService, UID as UID_KEY
 from threadcomponents.service.web_svc import WebService
-from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch
-from uuid import uuid4, UUID
+from uuid import uuid4
 from urllib.parse import quote
 
 
-def delete_db_file(file_path):
-    """Function to delete a local database test file."""
-    if file_path and os.path.isfile(file_path):
-        os.remove(file_path)
-    else:
-        logging.warning('Test DB file %s could not be deleted; accumulated data in-between test runs expected.'
-                        % file_path)
-
-
-# A test suite for checking our SQL-generating code
-class TestDBSQL(IsolatedAsyncioTestCase):
-    DB_TEST_FILE = os.path.join('tests', 'threadtestsql.db')
-
-    @classmethod
-    def setUpClass(cls):
-        """Any setting-up before all the test methods."""
-        cls.db = ThreadSQLite(cls.DB_TEST_FILE)
-        schema_file = os.path.join('threadcomponents', 'conf', 'schema.sql')
-        with open(schema_file) as schema_opened:
-            cls.schema = schema_opened.read()
-        cls.backup_schema = cls.db.generate_copied_tables(cls.schema)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Any tidying-up after all the test methods."""
-        # Delete the database so a new DB file is used in next test-run
-        delete_db_file(cls.DB_TEST_FILE)
-
-    async def asyncSetUp(self):
-        """Any setting-up before each test method."""
-        # Build the database (can't run in setUpClass() as this is an async method)
-        await self.db.build(self.schema)
-        await self.db.build(self.backup_schema)
-        await self.db.initialise_column_names()
-
-    async def check_data_appeared_in_table(self, table, method_name='unspecified', found_check=None, expect_found=True,
-                                           fail_msg='', **kwargs):
-        """
-        Function to check whether or not data is found in a table.
-        :param table: The table to check whether data has appeared.
-        :param method_name: The test method calling this method (for logging purposes).
-        :param found_check: The method to determine given a result from the database, if data is found.
-        :param expect_found: If we are checking data is found in the table or not.
-        :param fail_msg: The message to report on test failure.
-        **kwargs should match the kwargs of ThreadDB.get()
-        """
-        # If we don't have a way to do the check, fail this test
-        if not callable(found_check):
-            message = '%s: Not provided with method to check data is%s in table.' % \
-                      (method_name, '' if expect_found else ' not')
-            self.fail(message)
-        # Prefix failure message with test-method calling this method
-        fail_msg = '%s: %s' % (method_name, fail_msg if fail_msg else 'expected ' + str(expect_found))
-        # Obtain the sentences for the report and initialise a 'found' flag
-        results = await self.db.get(table, **kwargs)
-        found = False
-        # Check through the returned results to see if there is a match
-        for returned in results:
-            if found_check(returned):
-                found = True
-                break
-        # Check our expectations on whether the data is found or not
-        self.assertEqual(expect_found, found, msg=fail_msg)
-
-    async def test_build(self):
-        """Function to test the db built tables successfully."""
-        # SQLite-specific query to obtain table names
-        sql = 'SELECT name FROM %s WHERE type = \'table\';'
-        try:
-            results = await self.db.raw_select(sql % 'sqlite_schema', single_col=True)
-        except sqlite3.OperationalError:
-            # If the above fails, try the old name for the table for the lookup
-            try:
-                results = await self.db.raw_select(sql % 'sqlite_master', single_col=True)
-            except sqlite3.OperationalError:
-                # If this still fails, fail the test
-                self.fail('Unable to obtain table names from schema; raw_select() may be at fault.')
-        # The list of tables we are expecting to have been created
-        expected = ['attack_uids', 'reports', 'report_sentences', 'true_positives', 'true_negatives', 'false_positives',
-                    'false_negatives', 'regex_patterns', 'similar_words', 'report_sentence_hits', 'original_html',
-                    'report_sentences_initial', 'report_sentence_hits_initial', 'original_html_initial']
-        # Check the expectations against the results
-        for table in results:
-            self.assertTrue(table in expected, msg='Table %s was created but not expected.' % table)
-        for table in expected:
-            self.assertTrue(table in results, msg='Table %s was expected but not created.' % table)
-
-    async def test_insert(self):
-        """Function to test INSERT statements are generated correctly."""
-        # Test data to insert
-        data = dict(title='my_report', url='report.url', current_status=ReportStatus.QUEUE.value, token=None)
-        # Obtain the generated SQL
-        generated = await self.db.insert('reports', data, return_sql=True)
-        # The SQL we are expecting and the number of parameters we are expecting to be returned separately to the SQL
-        expected = 'INSERT INTO reports (title, url, current_status, token) VALUES (?, ?, ?, NULL)'
-        expected_params_len = 3
-        # Test expectations are correct
-        self.assertEqual(expected, generated[0], msg='SQL statement not generated as expected.')
-        self.assertEqual(expected_params_len, len(generated[1]), msg='SQL parameters not generated as expected.')
-
-    async def test_insert_with_uid(self):
-        """Function to test INSERT statements with generated UIDs are generated correctly."""
-        # Test data to insert
-        data = dict(title='my_report2', url='report2.url', current_status=ReportStatus.QUEUE.value, token=None)
-        # Obtain the generated SQL
-        generated = await self.db.insert_generate_uid('reports', data, return_sql=True)
-        # We are now expecting 4 parameters to be returned (as the UID has been generated)
-        expected_params_len = 4
-        # Test expectation is correct
-        self.assertEqual(expected_params_len, len(generated[1]), msg='SQL parameters not generated as expected.')
-        # Test valid UUID has been attached to the data; raises ValueError if invalid UUID
-        self.assertTrue(data[UID_KEY] in generated[1], msg='UID not passed to DB parameters.')
-        UUID(data[UID_KEY])
-
-    async def test_insert_then_update(self):
-        """Function to test inserted data can be updated successfully."""
-        # A small function to check given a report-record, that it matches with an initial title defined in this method
-        def pre_update_found(r):
-            return r.get('title') == initial_title and r.get('uid') == report_id
-
-        # A small function to check given a report-record, that it matches with an updated title defined in this method
-        def post_update_found(r):
-            return r.get('title') == new_title and r.get('uid') == report_id
-
-        # The test change we will be doing
-        initial_title = 'There and Back Again'
-        new_title = 'A Developer\'s Tale'
-        # Insert the report data
-        report = dict(title=initial_title, url='localhost.or.shire', current_status=ReportStatus.QUEUE.value)
-        report_id = await self.db.insert_generate_uid('reports', report)
-        # The kwargs for check_data_appeared_in_table() which are the same for all checks
-        checking_args = dict(method_name='test_insert_then_update', equal=dict(uid=report_id))
-        # Confirm the report got inserted
-        await self.check_data_appeared_in_table('reports', expect_found=True, found_check=pre_update_found,
-                                                fail_msg='inserted data not found', **checking_args)
-        # Confirm the new_title does not appear as a report title yet
-        rep_results = await self.db.get('reports', equal=dict(title=new_title))
-        if rep_results:
-            self.skipTest('Could not test updating table as tested updates already exist pre-update.')
-        # Update the report with the new title
-        await self.db.update('reports', where=dict(uid=report_id), data=dict(title=new_title))
-        # Confirm old report title is not found but new report title is found
-        await self.check_data_appeared_in_table('reports', expect_found=False, found_check=pre_update_found,
-                                                fail_msg='initial data found after update', **checking_args)
-        await self.check_data_appeared_in_table('reports', expect_found=True, found_check=post_update_found,
-                                                fail_msg='updated data not found', **checking_args)
-
-    async def test_insert_then_delete(self):
-        """Function to test inserted data can be deleted successfully."""
-        # A small function to check given a report-record, that it matches with a report ID defined in this method
-        def report_found(r):
-            return r.get('uid') == report_id
-
-        # Insert the report data
-        report = dict(title='Don\'t Stop Moving', url='funky.funky.beat', current_status=ReportStatus.QUEUE.value)
-        report_id = await self.db.insert_generate_uid('reports', report)
-        # The kwargs for check_data_appeared_in_table() which are the same for all checks
-        checking_args = dict(method_name='test_insert_then_delete', equal=dict(uid=report_id))
-        # Confirm the report got inserted
-        await self.check_data_appeared_in_table('reports', expect_found=True, found_check=report_found,
-                                                fail_msg='inserted data not found', **checking_args)
-        # Carry out the delete
-        await self.db.delete('reports', dict(uid=report_id))
-        # Confirm the report got deleted
-        await self.check_data_appeared_in_table('reports', expect_found=False, found_check=report_found,
-                                                fail_msg='deleted data was found', **checking_args)
-
-    async def test_select_with_no_args(self):
-        """Function to test behaviour of SELECT statements with no clauses specified."""
-        # Both calls should work without raising an error
-        await self.db.get('reports')
-        await self.db.get('reports', equal=None, not_equal=None, order_by_asc=None, order_by_desc=None)
-
-    async def test_insert_with_backup(self):
-        """Function to test inserting data with a backup works as expected."""
-        # A small function to check given a sentence-record, that it matches with the sentence defined in this method
-        def sentence_found(s):
-            return s.get('text') == sentence and s.get('uid') == sen_id
-        # Insert a report
-        report = dict(title='Return of the Phyrexian Obliterator', url='trampled.oops',
-                      current_status=ReportStatus.QUEUE.value)
-        report_id = await self.db.insert_generate_uid('reports', report)
-        # Confirm we have no sentences for this report yet
-        sen_results = await self.db.get('report_sentences', equal=dict(report_uid=report_id))
-        sen_results_backup = await self.db.get('report_sentences_initial', equal=dict(report_uid=report_id))
-        if sen_results or sen_results_backup:
-            self.skipTest('Could not test storing new data in backup tables as new data already exists.')
-
-        # Reports are not backed-up, so let's test a report-sentence which is backed up
-        sentence = 'Behold blessed perfection.'
-        data = dict(report_uid=report_id, text=sentence, html='<p>%s</p>' % sentence, sen_index=0,
-                    found_status=self.db.val_as_false)
-        sen_id = await self.db.insert_with_backup('report_sentences', data)
-        # The kwargs for check_data_appeared_in_table() which are the same for all checks
-        checking_args = dict(method_name='test_insert_with_backup', found_check=sentence_found,
-                             equal=dict(report_uid=report_id))
-        # After method is called, let's test both the report_sentences table and its back-up table have this sentence
-        for table in ['report_sentences', 'report_sentences_initial']:
-            error_msg = 'data missing in table %s after being inserted' % table
-            await self.check_data_appeared_in_table(table, expect_found=True, fail_msg=error_msg, **checking_args)
-        # Confirm deleting sentence in report_sentences does not delete the backup
-        await self.db.delete('report_sentences', dict(text=sentence))
-        await self.check_data_appeared_in_table(
-            'report_sentences', expect_found=False,
-            fail_msg='data deleted in report_sentences but found', **checking_args
-        )
-        await self.check_data_appeared_in_table(
-            'report_sentences_initial', expect_found=True,
-            fail_msg='data deleted in report_sentences and missing in report_sentences_initial', **checking_args
-        )
-
-    async def test_insert_with_no_data(self):
-        """Function to test behaviour of INSERT statements with no values specified."""
-        # TypeError where data to be inserted is None (not a dictionary)
-        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for report.'):
-            await self.db.insert('reports', None)
-        # ValueError where data to be inserted is (a dictionary but) empty
-        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for report.'):
-            await self.db.insert('reports', dict())
-
-    async def test_update_with_no_data(self):
-        """Function to test behaviour of UPDATE statements with no SET clause specified."""
-        # TypeError where data to be set is None (not a dictionary)
-        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for `data` parameter.'):
-            await self.db.update('reports', where=dict(title='Nothing is True'), data=None)
-        # ValueError where data to be set is (a dictionary but) empty
-        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for `data` parameter.'):
-            await self.db.update('reports', where=dict(title='Everything is Permitted; Except This'), data=dict())
-
-    async def test_update_with_no_where(self):
-        """Function to test behaviour of UPDATE statements with no WHERE clause specified."""
-        # TypeError where WHERE-clause data is None (not a dictionary)
-        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for `where` parameter.'):
-            await self.db.update('reports', where=None, data=dict(title='One title'))
-        # ValueError where WHERE-clause data is (a dictionary but) empty
-        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for `where` parameter.'):
-            await self.db.update('reports', where=dict(), data=dict(title='To Rule Them All'))
-
-    async def test_delete_with_no_where(self):
-        """Function to test behaviour of DELETE statements with no WHERE clause specified."""
-        # TypeError where WHERE-clause data is None (not a dictionary)
-        with self.assertRaises(TypeError, msg='Expected TypeError over `None` value for report.'):
-            await self.db.delete('reports', None)
-        # ValueError where WHERE-clause data is (a dictionary but) empty
-        with self.assertRaises(ValueError, msg='Expected ValueError over empty value for report.'):
-            await self.db.delete('reports', dict())
-
-
-# A test suite for checking report actions
 class TestReports(AioHTTPTestCase):
+    """A test suite for checking report actions."""
     DB_TEST_FILE = os.path.join('tests', 'threadtestreport.db')
 
     @classmethod
@@ -596,7 +347,7 @@ class TestReports(AioHTTPTestCase):
         for sen in sentences:
             # Find the sentence that has no prior-attacks for this test
             if sen.get('found_status') == self.db.val_as_false:
-                sen_id = sen.get('uid')
+                sen_id = sen.get(UID_KEY)
         if not sen_id:
             self.skipTest('Could not test adding an attack as report test sentences have attacks already.')
         # Proceed to add an attack
@@ -624,7 +375,7 @@ class TestReports(AioHTTPTestCase):
         for sen in sentences:
             # Find the sentence that has an attack for this test
             if sen.get('found_status') == self.db.val_as_true:
-                sen_id = sen.get('uid')
+                sen_id = sen.get(UID_KEY)
         if not sen_id:
             self.skipTest('Could not test confirming an attack as report test sentences do not have attacks.')
         # Proceed to confirm an attack
@@ -652,7 +403,7 @@ class TestReports(AioHTTPTestCase):
         for sen in sentences:
             # Find the sentence that has an attack for this test
             if sen.get('found_status') == self.db.val_as_true:
-                sen_id = sen.get('uid')
+                sen_id = sen.get(UID_KEY)
         if not sen_id:
             self.skipTest('Could not test rejecting an attack as report test sentences do not have attacks.')
         # Proceed to reject an attack
@@ -680,7 +431,7 @@ class TestReports(AioHTTPTestCase):
         for sen in sentences:
             # Find the sentence that has an attack for this test
             if sen.get('found_status') == self.db.val_as_true:
-                sen_id = sen.get('uid')
+                sen_id = sen.get(UID_KEY)
         if not sen_id:
             self.skipTest('Could not test getting sentence data as report test sentences do not have attacks.')
         # Obtain the sentence info
@@ -706,7 +457,7 @@ class TestReports(AioHTTPTestCase):
         self.assertEqual(resp_context_json[0].get('attack_uid'), 'd99999',
                          msg='Confirmed attack not associated with sentence as expected.')
         self.assertTrue(len(resp_attacks_json) > 0, msg='No confirmed attacks appearing for sentence.')
-        self.assertEqual(resp_attacks_json[0].get('uid'), 'd99999',
+        self.assertEqual(resp_attacks_json[0].get(UID_KEY), 'd99999',
                          msg='Confirmed attack not returned in confirmed attacks for sentence.')
 
     async def test_rollback_report(self):
@@ -719,14 +470,14 @@ class TestReports(AioHTTPTestCase):
         sentences = await self.db.get('report_sentences', equal=dict(report_uid=report_id),
                                       order_by_asc=dict(sen_index=1))
         # Obtain one of the sentence IDs
-        sen_id = sentences[0].get('uid')
+        sen_id = sentences[0].get(UID_KEY)
         # Delete the sentence
         data = dict(index='remove_sentence', sentence_id=sen_id)
         await self.client.post('/rest', json=data)
         # Confirm the sentence got deleted
         new_sentences = await self.db.get('report_sentences', equal=dict(report_uid=report_id),
                                           order_by_asc=dict(sen_index=1))
-        if len(sentences) - 1 != len(new_sentences) or new_sentences[0].get('uid') == sen_id:
+        if len(sentences) - 1 != len(new_sentences) or new_sentences[0].get(UID_KEY) == sen_id:
             self.fail('Could not test report rollback as removing a sentence did not work as expected.')
         # Rollback the report
         data = dict(index='rollback_report', report_title=report_title)
@@ -738,5 +489,5 @@ class TestReports(AioHTTPTestCase):
         self.assertEqual(len(sentences), len(rollback_sentences),
                          msg='Report-rollback resulted in a different number of report sentences.')
         # Check that the first sentence is the one we previously deleted
-        self.assertEqual(rollback_sentences[0].get('uid'), sen_id,
+        self.assertEqual(rollback_sentences[0].get(UID_KEY), sen_id,
                          msg='Report-rollback resulted in a different first sentence.')

--- a/tests/thread_app_test.py
+++ b/tests/thread_app_test.py
@@ -1,0 +1,166 @@
+import aiohttp_jinja2
+import asyncio
+import jinja2
+import os
+import random
+import sqlite3
+
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase
+from contextlib import suppress
+from stix2.base import _STIXBase
+from tests.misc import delete_db_file, SCHEMA_FILE
+from threadcomponents.database.dao import Dao
+from threadcomponents.database.thread_sqlite3 import ThreadSQLite
+from threadcomponents.handlers.web_api import WebAPI
+from threadcomponents.service import data_svc
+from threadcomponents.service.data_svc import DataService, NO_DESC
+from threadcomponents.service.ml_svc import MLService
+from threadcomponents.service.reg_svc import RegService
+from threadcomponents.service.rest_svc import RestService
+from threadcomponents.service.web_svc import WebService
+from unittest.mock import MagicMock, patch
+
+
+class ThreadAppTest(AioHTTPTestCase):
+    """A Thread test case that involves interacting with the application."""
+    DB_TEST_FILE = os.path.join('tests', 'threadtest.db')
+
+    @classmethod
+    def setUpClass(cls):
+        """Any setting-up before all the test methods."""
+        cls.db = ThreadSQLite(cls.DB_TEST_FILE)
+        with open(SCHEMA_FILE) as schema_opened:
+            cls.schema = schema_opened.read()
+        cls.backup_schema = cls.db.generate_copied_tables(cls.schema)
+        cls.dao = Dao(engine=cls.db)
+        cls.web_svc = WebService()
+        cls.reg_svc = RegService(dao=cls.dao)
+        cls.data_svc = DataService(dao=cls.dao, web_svc=cls.web_svc)
+        cls.ml_svc = MLService(web_svc=cls.web_svc, dao=cls.dao)
+        cls.rest_svc = RestService(cls.web_svc, cls.reg_svc, cls.data_svc, cls.ml_svc, cls.dao,
+                                   attack_file_settings=dict(update=False))
+        services = dict(dao=cls.dao, data_svc=cls.data_svc, ml_svc=cls.ml_svc, reg_svc=cls.reg_svc, web_svc=cls.web_svc,
+                        rest_svc=cls.rest_svc)
+        cls.web_api = WebAPI(services=services)
+        # Duplicate resources so we can test the queue limit without causing limit-exceeding test failures elsewhere
+        cls.rest_svc_with_limit = RestService(cls.web_svc, cls.reg_svc, cls.data_svc, cls.ml_svc, cls.dao,
+                                              queue_limit=random.randint(1, 20))
+        services_with_limit = dict(services)
+        services_with_limit.update(rest_svc=cls.rest_svc_with_limit)
+        cls.web_api_with_limit = WebAPI(services=services_with_limit)
+        # Some test-attack data
+        cls.attacks = dict(d99999='Drain', f12345='Fire', f32451='Firaga', s00001='requiem')
+
+    @classmethod
+    def tearDownClass(cls):
+        """Any tidying-up after all the test methods."""
+        # Delete the database so a new DB file is used in next test-run
+        delete_db_file(cls.DB_TEST_FILE)
+
+    async def setUpAsync(self):
+        """Any setting-up before each test method."""
+        # Build the database (can't run in setUpClass() as this is an async method)
+        await self.db.build(self.schema)
+        await self.db.build(self.backup_schema)
+        # Insert some attack data
+        a1_name, a2_name, a3_name = self.attacks.get('f12345'), self.attacks.get('f32451'), self.attacks.get('d99999')
+        a4_name = self.attacks.get('s00001')
+        attack_1 = dict(uid='f12345', description='Fire spell costing 4MP', tid='T1562', name=a1_name)
+        attack_2 = dict(uid='f32451', description='Stronger Fire spell costing 16MP', tid='T1562.004', name=a2_name)
+        attack_3 = dict(uid='d99999', description='Absorbs HP', tid='T1029', name=a3_name)
+        attack_4 = dict(uid='s00001', description='Damages all enemies', tid='T1485', name=a4_name, inactive=1)
+        for attack in [attack_1, attack_2, attack_3, attack_4]:
+            # Ignoring Integrity Error in case other test case already has inserted this data (causing duplicate UIDs)
+            with suppress(sqlite3.IntegrityError):
+                await self.db.insert('attack_uids', attack)
+        # Carry out pre-launch tasks except for prepare_queue(): replace the call of this to return (and do) nothing
+        # We don't want multiple prepare_queue() calls so the queue does not accumulate between tests
+        with patch.object(RestService, 'prepare_queue', return_value=None):
+            await self.web_api.pre_launch_init()
+            await self.web_api_with_limit.pre_launch_init()
+        await super().setUpAsync()
+
+    def create_patch(self, **patch_kwargs):
+        """A helper method to create, start and schedule the end of a patch."""
+        patcher = patch.object(**patch_kwargs)
+        started_patch = patcher.start()
+        self.addCleanup(patcher.stop)
+        return started_patch
+
+    async def get_application(self):
+        """Overrides AioHTTPTestCase.get_application()."""
+        app = web.Application()
+        # Some of the routes we'll be testing
+        app.router.add_route('GET', self.web_svc.get_route(WebService.HOME_KEY), self.web_api.index)
+        app.router.add_route('GET', self.web_svc.get_route(WebService.EDIT_KEY), self.web_api.edit)
+        app.router.add_route('GET', self.web_svc.get_route(WebService.ABOUT_KEY), self.web_api.about)
+        app.router.add_route('*', self.web_svc.get_route(WebService.REST_KEY), self.web_api.rest_api)
+        # A different route for limit-testing
+        app.router.add_route('*', '/limit' + self.web_svc.get_route(WebService.REST_KEY),
+                             self.web_api_with_limit.rest_api)
+        aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader(os.path.join('webapp', 'html')))
+        return app
+
+    def reset_queue(self, rest_svc=None):
+        """Function to reset the queue variables from a test RestService instance."""
+        # Default parameter for rest service if not provided
+        rest_svc = rest_svc or self.rest_svc
+        # Note all tasks in the queue object as done
+        with suppress(asyncio.QueueEmpty):
+            for _ in range(rest_svc.queue.qsize()):
+                rest_svc.queue.get_nowait()
+                rest_svc.queue.task_done()
+        # Reset the other variables
+        rest_svc.queue_map = dict()
+        rest_svc.clean_current_tasks()
+
+    async def submit_test_report(self, report, fail_map_html=False):
+        """A helper method to submit a test report and create some associated test-sentences."""
+        # Some test sentences and expected analysed html for them
+        sen1 = 'When Creating Test Data...'
+        sen2 = 'i. It can be quite draining'
+        html = [{'html': sen1, 'text': sen1, 'tag': 'p', 'ml_techniques_found': [], 'res_techniques_found': []},
+                {'html': sen2, 'text': sen2, 'tag': 'li', 'ml_techniques_found': [('d99999', 'Drain')],
+                 'res_techniques_found': []}]
+        # The result of the mapping function (no html, no Article object)
+        map_result = None, None
+        if not fail_map_html:
+            # If we are not failing the mapping stage, mock the newspaper.Article for the mapping returned object
+            mocked_article = MagicMock()
+            mocked_article.text = '%s\n%s' % (sen1, sen2)
+            map_result = html, mocked_article
+        # Patches for when RestService.start_analysis() is called
+        self.create_patch(target=WebService, attribute='map_all_html', return_value=map_result)
+        self.create_patch(target=DataService, attribute='ml_reg_split', return_value=([], list(self.attacks.items())))
+        self.create_patch(target=MLService, attribute='build_pickle_file', return_value=(False, dict()))
+        self.create_patch(target=MLService, attribute='analyze_html', return_value=html)
+
+        # Update relevant queue and insert report in DB as these tasks would have been done before submission
+        queue = self.rest_svc.get_queue_for_user()
+        queue.append(report['url'])
+        await self.db.insert('reports', report)
+        # Mock the analysis of the report
+        await self.rest_svc.start_analysis(criteria=report)
+
+    def mock_current_attack_data(self, attack_list=None):
+        """Helper-method to mock the retrieval of the current Att%ck data by returning a specified attack-list."""
+        attack_list = attack_list or []
+        new_attack_list = []
+        # For each attack in the given list, create an entry that follows the format from what is usually retrieved
+        for attack in attack_list:
+            tid = attack.get('tid', 'Txxxx')
+            new_attack_list.append(dict(
+                type='attack-pattern', modified='2022-03-7T00:00:00.000Z', name=attack.get('name', 'No name'),
+                created='2001-07-19T00:00:00.000Z', id=attack.get('uid', random.randint(0, 999999999)),
+                revoked=True, spec_version='2.1', description=attack.get('description', NO_DESC),
+                external_references=[
+                    {'url': 'https://attack.mitre.org/techniques/' + tid,
+                     'external_id': tid, 'source_name': 'mitre-attack'}
+                ],
+                x_mitre_attack_spec_version='2.1.0', x_mitre_domains=['enterprise-attack'], x_mitre_version='1.0',
+            ))
+        # Mock the fetch-data method to return our mocked list
+        self.create_patch(target=data_svc, attribute='fetch_attack_data', return_value=dict(objects=new_attack_list))
+        # Prevent the Stix library flagging incorrect data
+        self.create_patch(target=_STIXBase, attribute='_check_property', return_value=False)

--- a/tests/threadtests.py
+++ b/tests/threadtests.py
@@ -503,7 +503,7 @@ class TestReports(AioHTTPTestCase):
         # Patches for when RestService.start_analysis() is called
         self.create_patch(target=WebService, attribute='map_all_html', return_value=map_result)
         self.create_patch(target=DataService, attribute='ml_reg_split', return_value=([], list(self.attacks.items())))
-        self.create_patch(target=MLService, attribute='build_pickle_file', return_value=dict())
+        self.create_patch(target=MLService, attribute='build_pickle_file', return_value=(False, dict()))
         self.create_patch(target=MLService, attribute='analyze_html', return_value=html)
 
         # Update relevant queue and insert report in DB as these tasks would have been done before submission

--- a/threadcomponents/conf/config.yml
+++ b/threadcomponents/conf/config.yml
@@ -29,7 +29,14 @@ max-analysis-tasks: 1
 # The following fields are optional - please check comments for behaviour when omitted.
 
 # The JSON file containing attack data; ensure file is in /models directory
-# MUST BE SET if taxii-local = 'local-json'
-json_file: enterprise-attack.json
+# If taxii-local = 'local-json', the database will import this data.
+# Regardless, the models will use any examples (field, 'example_uses') for attacks from this file (or our default).
+json_file: attack_dict.json
+# If taxii-local = 'taxii-server', this determines if you want the file `json_file` to be updated with the server-data.
+# If you do not use version-control (e.g. Git), we recommend you keep a backup of your file if you turn this setting on.
+update_json_file: False
+# Does your file `json_file` have each variable on a new line? If so, set the indent here; no indent means contents
+# - if `update_json_file` is True - condense to 1 line. For readability, we recommend a value of at least 2.
+json_file_indent: 2
 # The maximum number of reports allowed in the queue; for no limit, remove this field or set value x < 1
 queue_limit: 20

--- a/threadcomponents/conf/schema.sql
+++ b/threadcomponents/conf/schema.sql
@@ -4,6 +4,8 @@
 
 CREATE TABLE IF NOT EXISTS attack_uids (
     uid VARCHAR(60) PRIMARY KEY,
+    -- If this is an old attack (currently not in the Mitre Att&ck framework)
+    inactive BOOLEAN DEFAULT 0,
     -- Attack description
     description TEXT,
     -- Attack ID in the form of T<Number>

--- a/threadcomponents/database/dao.py
+++ b/threadcomponents/database/dao.py
@@ -43,6 +43,9 @@ class Dao:
     async def get_column_as_list(self, table, column):
         return await self.db.get_column_as_list(table, column)
 
+    async def get_dict_value_as_key(self, table, column_key, columns):
+        return await self.db.get_dict_value_as_key(table, column_key, columns)
+
     async def update(self, table, where=None, data=None, return_sql=False):
         return await self.db.update(table, where=where, data=data, return_sql=return_sql)
 

--- a/threadcomponents/database/thread_postgresql.py
+++ b/threadcomponents/database/thread_postgresql.py
@@ -142,7 +142,7 @@ class ThreadPostgreSQL(ThreadDB):
             return [desc[0] for desc in cursor.description]
         return self._connection_wrapper(cursor_select, cursor_factory=psycopg2.extras.DictCursor)
 
-    async def _execute_select(self, sql, parameters=None, single_col=False):
+    async def _execute_select(self, sql, parameters=None, single_col=False, on_fetch=None):
         """Implements ThreadDB._execute_select()"""
         def cursor_select(cursor):
             # Execute the SQL query with parameters or not
@@ -152,7 +152,10 @@ class ThreadPostgreSQL(ThreadDB):
                 cursor.execute(sql, parameters)
             # Return the rows as dictionaries
             rows = cursor.fetchall()
-            return [dict(ix) for ix in rows]
+            if callable(on_fetch):
+                return on_fetch(rows)
+            else:
+                return [dict(ix) for ix in rows]
         return self._connection_wrapper(cursor_select, cursor_factory=psycopg2.extras.DictCursor)
 
     async def _execute_insert(self, sql, data):

--- a/threadcomponents/handlers/web_api.py
+++ b/threadcomponents/handlers/web_api.py
@@ -49,7 +49,8 @@ class WebAPI:
         """Function to call any required methods before the app is initialised and launched."""
         # We want nltk packs downloaded before startup; not run concurrently with startup
         await self.ml_svc.check_nltk_packs()
-        # Before the app starts up, prepare the queue of reports
+        # Before the app starts up, prepare the queue of reports and class-variables
+        await self.rest_svc.initialise_lists()
         await self.rest_svc.prepare_queue()
         # We want the list of attacks ready before the app starts
         self.attack_dropdown_list = await self.data_svc.get_techniques(get_parent_info=True)

--- a/threadcomponents/handlers/web_api.py
+++ b/threadcomponents/handlers/web_api.py
@@ -352,7 +352,7 @@ class WebAPI:
             if sen_id not in seen_sentences:
                 dd['content'].append(sen_text)
                 seen_sentences.add(sen_id)
-            if sentence['attack_tid'] and sentence['active_hit']:
+            if sentence['attack_tid'] and sentence['active_hit'] and not sentence['inactive_attack']:
                 # Append any attack for this sentence to the table; prefix parent-tech for any sub-technique
                 tech_name, parent_tech = sentence['attack_technique_name'], sentence.get('attack_parent_name')
                 tech_name = "%s: %s" % (parent_tech, tech_name) if parent_tech else tech_name

--- a/threadcomponents/handlers/web_api.py
+++ b/threadcomponents/handlers/web_api.py
@@ -49,8 +49,7 @@ class WebAPI:
         """Function to call any required methods before the app is initialised and launched."""
         # We want nltk packs downloaded before startup; not run concurrently with startup
         await self.ml_svc.check_nltk_packs()
-        # Before the app starts up, prepare the queue of reports and class-variables
-        await self.rest_svc.initialise_lists()
+        # Before the app starts up, prepare the queue of reports
         await self.rest_svc.prepare_queue()
         # We want the list of attacks ready before the app starts
         self.attack_dropdown_list = await self.data_svc.get_techniques(get_parent_info=True)
@@ -394,12 +393,7 @@ class WebAPI:
                 techniques[row['uid']] = {'id': row['tid'], 'name': row['name'], 'similar_words': [],
                                           'example_uses': tp, 'false_positives': fp}
 
-        # query for true negatives
-        true_negatives = []
-        true_negs = await self.dao.get('true_negatives')
-        for i in true_negs:
-            true_negatives.append(i['sentence'])
-        list_of_legacy, list_of_techs = await self.data_svc.ml_reg_split(techniques)
-        self.ml_svc.build_pickle_file(list_of_techs, techniques, true_negatives, force=True)
+        list_of_legacy, list_of_techs = self.data_svc.ml_reg_split(techniques)
+        self.ml_svc.build_pickle_file(list_of_techs, techniques, force=True)
 
         return {'text': 'ML Rebuilt!'}

--- a/threadcomponents/service/data_svc.py
+++ b/threadcomponents/service/data_svc.py
@@ -84,8 +84,8 @@ class DataService:
 
     async def insert_attack_stix_data(self):
         """
-        Function to pull stix/taxii information and insert in to the local db
-        :return: status code
+        Function to retrieve ATT&CK data and insert it into the DB.
+        Further reading on approach: https://github.com/arachne-threat-intel/thread/pull/27#issuecomment-1047456689
         """
         logging.info('Downloading ATT&CK data from STIX/TAXII...')
         attack = {}

--- a/threadcomponents/service/data_svc.py
+++ b/threadcomponents/service/data_svc.py
@@ -18,6 +18,13 @@ NO_DESC = 'No description provided'
 FULL_ATTACK_INFO = 'full_attack_info'
 
 
+def fetch_attack_data():
+    """Function to fetch the latest Att%ck data."""
+    url = 'https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/' \
+          'enterprise-attack.json'
+    return requests.get(url).json()
+
+
 def defang_text(text):
     """
     Function to normalize quoted data to be sql compliant
@@ -86,9 +93,7 @@ class DataService:
         """
         logging.info('Downloading ATT&CK data from GitHub repo `mitre-attack/attack-stix-data`...')
         attack = {}
-        domain = "enterprise-attack"
-        github_url = f"https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/{domain}/{domain}.json"
-        stix_json = requests.get(github_url).json()
+        stix_json = fetch_attack_data()
         ms = MemoryStore(stix_data=stix_json["objects"])
         filter_objs = {"techniques": Filter("type", "=", "attack-pattern"),
                        "groups": Filter("type", "=", "intrusion-set"), "malware": Filter("type", "=", "malware"),

--- a/threadcomponents/service/data_svc.py
+++ b/threadcomponents/service/data_svc.py
@@ -7,6 +7,7 @@ import re
 import json
 import logging
 
+from contextlib import suppress
 from stix2 import TAXIICollectionSource, Filter
 from urllib.parse import quote
 
@@ -271,6 +272,21 @@ class DataService:
     async def get_technique_uids(self):
         """A function to obtain the list of attack IDs from the db."""
         return await self.dao.get_column_as_list(table='attack_uids', column='uid')
+
+    async def get_report_id_from_sentence_id(self, sentence_id=None):
+        """Function to retrieve the report ID from a sentence ID."""
+        if not sentence_id:
+            return None
+        # Determine if sentence or image
+        sentence_dict = await self.dao.get('report_sentences', dict(uid=sentence_id))
+        img_dict = await self.dao.get('original_html', dict(uid=sentence_id))
+        # Get the report ID from either
+        report_id = None
+        with suppress(KeyError, IndexError):
+            report_id = sentence_dict[0]['report_uid']
+        with suppress(KeyError, IndexError):
+            report_id = img_dict[0]['report_uid']
+        return report_id
 
     async def get_confirmed_attacks_for_sentence(self, sentence_id=''):
         """Function to retrieve confirmed-attack data for a sentence."""

--- a/threadcomponents/service/data_svc.py
+++ b/threadcomponents/service/data_svc.py
@@ -134,7 +134,8 @@ class DataService:
         attack_data = references
         logging.info("Finished...now creating the database.")
 
-        cur_uids = await self.get_technique_uids()
+        cur_attacks = await self.dao.get_dict_value_as_key('attack_uids', 'uid', 'name')
+        cur_uids = list(cur_attacks.keys())
         for k, v in attack_data.items():
             if k not in cur_uids:
                 await self.dao.insert('attack_uids', dict(uid=k, description=defang_text(v.get('description', NO_DESC)),

--- a/threadcomponents/service/ml_svc.py
+++ b/threadcomponents/service/ml_svc.py
@@ -202,6 +202,7 @@ class MLService:
             attack_technique = attack_uid[0]['uid']
             attack_technique_name = '{} (m)'.format(attack_uid[0]['name'])
             attack_tid = attack_uid[0]['tid']
+            # Allow 'inactive' attacks to be recorded: they will be filtered out when viewing/exporting a report
             await self.dao.insert_with_backup(
                 'report_sentence_hits',
                 dict(sentence_id=sentence_id, attack_uid=attack_technique, attack_technique_name=attack_technique_name,

--- a/threadcomponents/service/rest_svc.py
+++ b/threadcomponents/service/rest_svc.py
@@ -62,6 +62,11 @@ class RestService:
         attack_dict_loc = os.path.join(dir_prefix, 'threadcomponents', 'models', 'attack_dict.json')
         with open(attack_dict_loc, 'r', encoding='utf_8') as attack_dict_f:
             self.json_tech = json.load(attack_dict_f)
+        self.list_of_legacy, self.list_of_techs = [], []
+
+    async def initialise_lists(self):
+        """Function to initialise internal lists."""
+        self.list_of_legacy, self.list_of_techs = await self.data_svc.ml_reg_split(self.json_tech)
 
     @staticmethod
     def get_status_enum():
@@ -437,14 +442,13 @@ class RestService:
 
         html_data = newspaper_article.text.replace('\n', '<br>')
         article = dict(title=criteria['title'], html_text=html_data)
-        list_of_legacy, list_of_techs = await self.data_svc.ml_reg_split(self.json_tech)
 
         true_negatives = await self.ml_svc.get_true_negs()
         # Here we build the sentence dictionary
         html_sentences = self.web_svc.tokenize_sentence(article['html_text'])
-        model_dict = await self.ml_svc.build_pickle_file(list_of_techs, self.json_tech, true_negatives)
+        model_dict = await self.ml_svc.build_pickle_file(self.list_of_techs, self.json_tech, true_negatives)
 
-        ml_analyzed_html = await self.ml_svc.analyze_html(list_of_techs, model_dict, html_sentences)
+        ml_analyzed_html = await self.ml_svc.analyze_html(self.list_of_techs, model_dict, html_sentences)
         regex_patterns = await self.dao.get('regex_patterns')
         reg_analyzed_html = self.reg_svc.analyze_html(regex_patterns, html_sentences)
 

--- a/threadcomponents/service/rest_svc.py
+++ b/threadcomponents/service/rest_svc.py
@@ -505,6 +505,10 @@ class RestService:
                                                           attack_id=attack_id, attack_dict=attack_dict)
         if checks is not None:
             return checks
+        a_name, tid, inactive = attack_dict[0]['name'], attack_dict[0]['tid'], attack_dict[0]['inactive']
+        if inactive:
+            return dict(error="%s, '%s' is not in the current Att%%ck framework. " % (tid, a_name) +
+                              'Please contact us if this is incorrect.', alert_user=1)
         # Get the sentence to insert by removing html markup
         sentence_to_insert = await self.web_svc.remove_html_markup_and_found(sentence_dict[0]['text'])
         # A flag to determine if the model initially predicted this attack for this sentence
@@ -528,9 +532,8 @@ class RestService:
             # Insert new row in the report_sentence_hits database table to indicate a new confirmed technique
             # This is needed to ensure that requests to get all confirmed techniques works correctly
             sql_commands.append(await self.dao.insert_generate_uid(
-                'report_sentence_hits', dict(sentence_id=sen_id, attack_uid=attack_id, attack_tid=attack_dict[0]['tid'],
-                                             attack_technique_name=attack_dict[0]['name'],
-                                             report_uid=sentence_dict[0]['report_uid'],
+                'report_sentence_hits', dict(sentence_id=sen_id, attack_uid=attack_id, attack_tid=tid,
+                                             attack_technique_name=a_name, report_uid=sentence_dict[0]['report_uid'],
                                              confirmed=self.dao.db_true_val), return_sql=True))
         # As this will now be either a true positive or false negative, ensure it is not a false positive too
         sql_commands.append(await self.dao.delete('false_positives', dict(sentence_id=sen_id, attack_uid=attack_id),

--- a/threadcomponents/service/web_svc.py
+++ b/threadcomponents/service/web_svc.py
@@ -22,6 +22,8 @@ from urllib.parse import urlparse
 
 # Abbreviated words for sentence-splitting
 ABBREVIATIONS = {'dr', 'vs', 'mr', 'mrs', 'ms', 'prof', 'inc', 'fig', 'e.g', 'i.e', 'u.s'}
+# Blocked image types
+BLOCKED_IMG_TYPES = {'gif', 'apng', 'webp', 'avif', 'mng', 'flif'}
 
 
 class WebService:
@@ -135,6 +137,9 @@ class WebService:
                             source = cur_img['src']
                         # All img tags should have a src attribute. In case this one doesn't, there is no image to save
                         except KeyError:
+                            continue
+                        # If no source was obtained or this image is a blocked filetype: continue
+                        if not source or any(source.lower().endswith(img_type) for img_type in BLOCKED_IMG_TYPES):
                             continue
                         img_dict = await self._match_and_construct_img(images, source)
                         if source not in seen_images:

--- a/threadcomponents/service/web_svc.py
+++ b/threadcomponents/service/web_svc.py
@@ -174,7 +174,7 @@ class WebService:
         seen_sentence_idxs = set()
         # Iterate through each html element to match it to its sentence and build final html
         for element in original_html:
-            if element['tag'] == 'img' or element['tag'] == 'header':
+            if element['tag'] == 'img':
                 final_element = await self._build_final_image_dict(element)
                 final_html.append(final_element)
                 # This isn't a sentence but reflect something has been added to final_html by adding -1

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -35,17 +35,19 @@
   <div class="col reportSentencesDiv">
     {% for elmt in final_html %}
       {% if elmt.tag == 'img' %}
-        <img src="{{elmt.text}}" id="img{{elmt.uid}}" class="reportImage" onclick="sentenceContext('{{elmt.uid}}')"> <br class="elmtRelated{{elmt.uid}}"><br class="elmtRelated{{elmt.uid}}">
-      {% elif elmt.tag == 'header' %}
-        <h3>{{elmt.text}}</h3>
-      {% elif elmt.tag == 'li' and elmt.found_status %}
-        <li class="elmtRelated{{elmt.uid}}"><span class="bg-warning report-sentence" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</span></li> <br class="elmtRelated{{elmt.uid}}">
-      {% elif elmt.tag == 'li' %}
-        <li class="elmtRelated{{elmt.uid}}"><span id="elmt{{elmt.uid}}" class="report-sentence" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</span></li> <br class="elmtRelated{{elmt.uid}}">
-      {% elif elmt.found_status %}
-        <span class="bg-warning report-sentence" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</span> <br class="elmtRelated{{elmt.uid}}"><br class="elmtRelated{{elmt.uid}}">
+        <img src="{{elmt.text}}" id="img{{elmt.uid}}" class="reportImage" onclick="sentenceContext('{{elmt.uid}}')">
       {% else %}
-        <span class="report-sentence" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">{{elmt.text}}</span> <br class="elmtRelated{{elmt.uid}}"><br class="elmtRelated{{elmt.uid}}">
+        {% if elmt.tag == 'li' %}<li class="elmtRelated{{elmt.uid}}">{% endif %}
+        {% if elmt.tag == 'header' %}<h3 class="elmtRelated{{elmt.uid}}">{% endif %}
+        <span class="report-sentence {% if elmt.found_status %}bg-warning{% endif %}" id="elmt{{elmt.uid}}" onclick="sentenceContext('{{elmt.uid}}')">
+          {{elmt.text}}
+        </span>
+        {% if elmt.tag == 'header' %}</h3>{% endif %}
+        {% if elmt.tag == 'li' %}</li>{% endif %}
+      {% endif %}
+      <br class="elmtRelated{{elmt.uid}}">{# Initial space to separate sentences #}
+      {% if elmt.tag != 'li' and elmt.tag != 'header' %}{# Non-li's and non-headers need extra spacing #}
+        <br class="elmtRelated{{elmt.uid}}">
       {% endif %}
     {% endfor %}
   </div>

--- a/webapp/theme/style/style.css
+++ b/webapp/theme/style/style.css
@@ -290,7 +290,7 @@ table {
   cursor: help;
 }
 
-.report-action {
+.report-action, .dropdown-item {
   cursor: pointer;
 }
 


### PR DESCRIPTION
- Bugfix where submitting a deleted error'ed report could not be resubmitted
- Blocks certain image types
- Made headers clickable
- Organised test-suite into smaller test cases

Collect updates for Att&ck data:
- For attacks already in Thread's database:
   - Checks if the name has changed; if so, updates old names to be new attack names
- For new attacks:
   - Adds them to the db
- For obsolete attacks:
   - DB schema now has 'inactive' flag for attack (such attacks do not appear in the front end)
- Schedules the update to be monthly

*Sorry for the large PR again, I underestimated the scope of the Att&ck data updates and bundled it with bugfixes/smaller tickets; organising the test-suite whilst adding more tests also is culpable for the largeness of the PR