### PR TITLE
Using a dedup func instead of using a `set` to de-duplicate items

### DIFF
--- a/threadcomponents/helpers/list_helpers.py
+++ b/threadcomponents/helpers/list_helpers.py
@@ -1,0 +1,5 @@
+# Copied from here: https://stackoverflow.com/a/480227
+def dedup_list(list):
+    seen = set()
+    seen_add = seen.add
+    return [x for x in list if not (x in seen or seen_add(x))]

--- a/threadcomponents/helpers/list_helpers.py
+++ b/threadcomponents/helpers/list_helpers.py
@@ -1,5 +1,5 @@
 # Copied from here: https://stackoverflow.com/a/480227
-def dedup_list(list):
+def dedup_list(list_to_dedupe):
     seen = set()
     seen_add = seen.add
-    return [x for x in list if not (x in seen or seen_add(x))]
+    return [x for x in list_to_dedupe if not (x in seen or seen_add(x))]

--- a/threadcomponents/service/web_svc.py
+++ b/threadcomponents/service/web_svc.py
@@ -20,6 +20,8 @@ from nltk.corpus import stopwords
 from nltk.stem import SnowballStemmer
 from urllib.parse import urlparse
 
+from threadcomponents.helpers.list_helpers import dedup_list
+
 # Abbreviated words for sentence-splitting
 ABBREVIATIONS = {'dr', 'vs', 'mr', 'mrs', 'ms', 'prof', 'inc', 'fig', 'e.g', 'i.e', 'u.s'}
 # Blocked image types
@@ -355,14 +357,14 @@ class WebService:
         :criteria: expects a dictionary of this structure:
         """
         html_sentences = self.tokenizer_sen.tokenize(data)
-        corrected_html_sentences = set(self.__correct_sentences(html_sentences))
+        corrected_html_sentences = dedup_list(self.__correct_sentences(html_sentences))
 
         sentences = []
         for current in corrected_html_sentences:
             if sentence_limit and (len(sentences) >= sentence_limit):
                 break
             # Further split by break tags as this might misplace highlighting in the front end
-            no_breaks = set([x for x in current.split('<br>') if x])
+            no_breaks = dedup_list([x for x in current.split('<br>') if x])
             for fragment in no_breaks:
                 sentence_data = dict()
                 sentence_data['html'] = fragment
@@ -370,6 +372,7 @@ class WebService:
                 sentence_data['ml_techniques_found'] = []
                 sentence_data['reg_techniques_found'] = []
                 sentences.append(sentence_data)
+
         return sentences
 
     @staticmethod


### PR DESCRIPTION
This should fix items coming in out of order.

The items coming out of order was due to using a `set` to try and avoid duplicates but that was putting things out of order. So this simply introduces a `dedup_list` function to fix that.

In a way this also fixes some of the duplicates that were coming through but because of the way data was being extracted from Newspaper, it doesn't fix all of them.

I will look into the newspaper code next to see if something can be done there to fix the issue at the source. There's always the option to put an ambulance at the bottom of the cliff to de-duplicate everything on the `return`.