### PR TITLE
Remove the use of set

### DIFF
--- a/threadcomponents/service/web_svc.py
+++ b/threadcomponents/service/web_svc.py
@@ -355,14 +355,14 @@ class WebService:
         :criteria: expects a dictionary of this structure:
         """
         html_sentences = self.tokenizer_sen.tokenize(data)
-        corrected_html_sentences = set(self.__correct_sentences(html_sentences))
+        corrected_html_sentences = self.__correct_sentences(html_sentences)
 
         sentences = []
         for current in corrected_html_sentences:
             if sentence_limit and (len(sentences) >= sentence_limit):
                 break
             # Further split by break tags as this might misplace highlighting in the front end
-            no_breaks = set([x for x in current.split('<br>') if x])
+            no_breaks = [x for x in current.split('<br>') if x]
             for fragment in no_breaks:
                 sentence_data = dict()
                 sentence_data['html'] = fragment


### PR DESCRIPTION
Now that the issue is fixed in the newspaper to not create duplicates (https://github.com/jecarr/newspaper/pull/2), we can remove the use of `set` here.