### PR TITLE
AFB Export

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ async def init(host, port, app_setup_func=None):
     app.router.add_route("*", web_svc.get_route(WebService.REST_KEY), website_handler.rest_api)
     app.router.add_route("GET", web_svc.get_route(WebService.EXPORT_PDF_KEY), website_handler.pdf_export)
     app.router.add_route("GET", web_svc.get_route(WebService.EXPORT_NAV_KEY), website_handler.nav_export)
+    app.router.add_route("GET", web_svc.get_route(WebService.EXPORT_AFB_KEY), website_handler.afb_export)
     app.router.add_route("GET", web_svc.get_route(WebService.COOKIE_KEY), website_handler.accept_cookies)
     if not web_svc.is_local:
         app.router.add_route("GET", web_svc.get_route(WebService.WHAT_TO_SUBMIT_KEY), website_handler.what_to_submit)

--- a/tests/test_afb_export.py
+++ b/tests/test_afb_export.py
@@ -1,0 +1,237 @@
+import os
+
+from datetime import datetime
+from tests.thread_app_test import ThreadAppTest
+from threadcomponents.constants import UID as UID_KEY
+from uuid import uuid4
+
+
+class TestAFBExport(ThreadAppTest):
+    """A test suite for checking AFB-export of reports."""
+
+    DB_TEST_FILE = os.path.join("tests", "threadtestafbexport.db")
+
+    async def setUpAsync(self):
+        await super().setUpAsync()
+
+        self.report_id, self.report_title = str(uuid4()), "Blitzball: A Guide"
+        await self.submit_test_report(
+            dict(
+                uid=self.report_id,
+                title=self.report_title,
+                url="lets.blitz",
+                date_written="2025-07-25",
+            ),
+            sentences=[
+                ":~$ echo $JECHT_SHOT",
+                "For more test data, I need to say some random IP addresses.",
+                "2607[:]f8b0[:]400e[:]c01[::]8a",
+                "74[.]125[.]199[.]138",
+            ],
+            attacks_found=[
+                [("d99999", "Drain"), ("f32451", "Firaga"), ("s12345", "Yevon")],
+                [("d99999", "Drain"), ("f12345", "Fire")],
+                [],
+                [],
+            ],
+        )
+
+        self.report_id2, self.report_title2 = str(uuid4()), "Chocobo Racing: A Guide"
+        await self.submit_test_report(
+            dict(
+                uid=self.report_id2,
+                title=self.report_title2,
+                url="kw.eh",
+                date_written="2025-07-25",
+            ),
+            sentences=[
+                "Kweh.",
+                "Kweh!?",
+            ],
+            attacks_found=[
+                [("f32451", "Firaga")],
+                [],
+            ],
+            post_confirm_attack=True,
+            confirm_attack="f32451",
+        )
+
+        await self.confirm_report_attacks()
+        await self.save_report_iocs()
+
+    async def confirm_report_attacks(self):
+        """Confirms the attacks in the test-report."""
+        await self.confirm_report_sentence_attacks(self.report_id, 0, ["d99999", "s12345"])
+        await self.confirm_report_sentence_attacks(self.report_id, 1, ["f12345"])
+
+    async def save_report_iocs(self):
+        """Saves the IoCs in the test-report."""
+        sentence = await self.db.get("report_sentences", equal=dict(report_uid=self.report_id, sen_index=0))
+        await self.client.post(
+            "/rest",
+            json=dict(
+                index="add_indicator_of_compromise",
+                sentence_id=sentence[0][UID_KEY],
+                ioc_text="echo $JECHT_SHOT",
+            ),
+        )
+
+        for sentence_index in range(2, 4):
+            sentence = await self.db.get(
+                "report_sentences",
+                equal=dict(report_uid=self.report_id, sen_index=sentence_index),
+            )
+            await self.client.post(
+                "/rest",
+                json=dict(
+                    index="suggest_and_save_ioc",
+                    sentence_id=sentence[0][UID_KEY],
+                ),
+            )
+
+    async def get_export_afb_response(self):
+        """Requests the AFB export and returns the response."""
+        return await self.client.get("/export/afb/Blitzball%3A%20A%20Guide")
+
+    async def get_attached_afb_as_json(self):
+        """Returns the exported AFB as json."""
+        response = await self.get_export_afb_response()
+        return await response.json()
+
+    @staticmethod
+    def get_entries_from_export(exported, id_value):
+        """Returns the entries from the exported data given an ID-type."""
+        all_objects = exported["objects"]
+        filtered_list = []
+
+        for current in all_objects:
+            if current["id"] == id_value:
+                filtered_list.append(current)
+
+        return filtered_list
+
+    async def trigger_object_by_id_value_test(self, id_value, expected_properties):
+        """Given an ID-value in the objects-list, tests the objects for that ID-value are correct."""
+        exported = await self.get_attached_afb_as_json()
+
+        retrieved = self.get_entries_from_export(exported, id_value)
+        expected_count = len(expected_properties)
+        self.assertEqual(len(retrieved), expected_count, f"{expected_count} x {id_value} entries not set.")
+
+        for current in retrieved:
+            current_props = dict(current["properties"])
+
+            for key, value in current_props.items():
+                if isinstance(value, list):
+                    current_props[key] = dict(value)
+
+            self.assertTrue(current_props in expected_properties, f"{id_value} object is an unexpected entry.")
+
+    async def test_response_headers(self):
+        """Tests the response headers reflect an attachment."""
+        response = await self.get_export_afb_response()
+
+        self.assertEqual(response.content_disposition.type, "attachment", "Response is not an attachment.")
+        self.assertEqual(
+            response.content_disposition.filename,
+            "Blitzball__A_Guide.afb",
+            "Attachment's filename is different than expected.",
+        )
+
+    async def test_schema(self):
+        """Tests the schema is correctly set in the export."""
+        exported = await self.get_attached_afb_as_json()
+        self.assertEqual(exported["schema"], "attack_flow_v2", "Schema not correctly set.")
+
+    async def test_camera_object(self):
+        """Tests the camera-object is correctly set in the export."""
+        exported = await self.get_attached_afb_as_json()
+        camera = exported["camera"]
+
+        camera_fields = sorted(camera.keys())
+        self.assertEqual(camera_fields, ["k", "x", "y"], "Camera-object not correctly set.")
+
+        numbers_provided = all([isinstance(_, int) or isinstance(_, float) for _ in camera.values()])
+        self.assertTrue(numbers_provided, "Camera-values are not numbers.")
+
+    async def test_flow_object(self):
+        """Tests the flow-object is correctly set in the export."""
+        exported = await self.get_attached_afb_as_json()
+
+        flow_objects = self.get_entries_from_export(exported, "flow")
+        self.assertEqual(len(flow_objects), 1, "1 x Flow entry not set.")
+
+        properties = dict(flow_objects[0]["properties"])
+        self.assertEqual(properties["name"], self.report_title, "Report title not set in export.")
+
+        today = datetime.now()
+        exported_date = datetime.strptime(properties["created"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        self.assertEqual(today.date(), exported_date.date(), "Created timestamp is not of today.")
+
+        object_list = sorted(flow_objects[0]["objects"])
+        declared_ids = []
+
+        for current in exported["objects"]:
+            if current["id"] != "flow":
+                declared_ids.append(current["instance"])
+
+        self.assertEqual(object_list, sorted(declared_ids), "Objects-list has incorrect IDs.")
+
+    async def test_anchors_key_declared(self):
+        """Tests objects from the export have an anchor key."""
+        exported = await self.get_attached_afb_as_json()
+
+        for current in exported["objects"]:
+            if current["id"] != "flow":
+                self.assertTrue("anchors" in current, "Non-flow entry missing 'anchors' key.")
+
+    async def test_layout_object(self):
+        """Tests the layout-object is correctly set in the export."""
+        exported = await self.get_attached_afb_as_json()
+
+        flow_object = self.get_entries_from_export(exported, "flow")[0]
+        object_list = sorted(flow_object["objects"])
+        layout = exported["layout"]
+
+        layout_keys = sorted(layout.keys())
+        self.assertEqual(layout_keys, object_list, "Layout-object not correctly set.")
+
+        layout_values = [ln for l_coords in layout.values() for ln in l_coords]
+        numbers_provided = all([isinstance(_, int) or isinstance(_, float) for _ in layout_values])
+        self.assertTrue(numbers_provided, "Layout-values are not numbers.")
+
+    async def test_ipv6_object_declared(self):
+        """Tests an IPv6 entry is correctly included in the export."""
+        expected = dict(value="2607[:]f8b0[:]400e[:]c01[::]8a")
+        await self.trigger_object_by_id_value_test("ipv6_addr", [expected])
+
+    async def test_ipv4_object_declared(self):
+        """Tests an IPv4 entry is correctly included in the export."""
+        expected = dict(value="74[.]125[.]199[.]138")
+        await self.trigger_object_by_id_value_test("ipv4_addr", [expected])
+
+    async def test_process_object_declared(self):
+        """Tests a process-entry is correctly included in the export."""
+        expected = dict(command_line=":~$ echo $JECHT_SHOT")
+        await self.trigger_object_by_id_value_test("process", [expected])
+
+    async def test_malware_object_declared(self):
+        """Tests a malware-entry is correctly included in the export."""
+        expected = dict(name="Yevon")
+        await self.trigger_object_by_id_value_test("malware", [expected])
+
+    async def test_action_objects_declared(self):
+        """Tests action-entries are correctly included in the export."""
+        expected_1 = dict(
+            name="Drain",
+            technique_id="T1029",
+            technique_ref="d99999",
+            ttp=dict(technique="T1029"),
+        )
+        expected_2 = dict(
+            name="Fire",
+            technique_id="T1562",
+            technique_ref="f12345",
+            ttp=dict(technique="T1562"),
+        )
+        await self.trigger_object_by_id_value_test("action", [expected_1, expected_2])

--- a/threadcomponents/constants.py
+++ b/threadcomponents/constants.py
@@ -5,3 +5,6 @@ DATETIME_OBJ = "datetime_obj"
 UID = "uid"
 URL = "url"
 TITLE = "title"
+
+TTP = "ttp"
+IOC = "ioc"

--- a/threadcomponents/handlers/web_api.py
+++ b/threadcomponents/handlers/web_api.py
@@ -404,8 +404,8 @@ class WebAPI:
 
     async def afb_export(self, request):
         """Function to export report in AFB format."""
-        json_str = await self.report_exporter.afb_export(request)
-        return self.get_downloadable_export_response(json_str, "octet-stream", "data.afb")
+        filename, json_str = await self.report_exporter.afb_export(request)
+        return self.get_downloadable_export_response(json_str, "json", filename)
 
     async def nav_export(self, request):
         """

--- a/threadcomponents/reports/afb_exporter.py
+++ b/threadcomponents/reports/afb_exporter.py
@@ -1,10 +1,247 @@
+from datetime import datetime
+from ipaddress import ip_address, IPv4Address, IPv6Address
+from threadcomponents.constants import TTP, IOC
+from uuid import uuid4
+
+START_X = 0
+START_Y = -2000
+TILE_SHIFT = 400
+TILES_PER_ROW = 3
+
+NAME_CHAR_LIMIT = 60
+
+
 class AFBExporter:
     """A class to export report mappings in an AFB format."""
-    def __init__(self):
-        pass
 
-    async def export(self):
+    def __init__(self, report_title, report_data):
+        self.report_title = report_title
+        self.report_data = report_data
+        self.reset()
+
+    def reset(self):
+        self.exported = {
+            "schema": "attack_flow_v2",
+        }
+        self.objects = []
+        self.current_ids = set()
+
+        self.layout = {}
+        self.current_x = START_X
+        self.current_y = START_Y
+
+        self.name = ""
+        self.description = None
+        self.errors = []
+
+    def export(self):
         """Executes the export."""
-        data = {}
+        self.reset()
+        self._set_name_and_description()
+        self._build_objects_list()
+        self._add_layout_object()
+        self._add_camera_object()
+        return self.exported
 
-        return data
+    def _build_objects_list(self):
+        """Build the objects list to be included in the exported data."""
+        for data in self.report_data:
+            data_type = data.get("type")
+            mapping_key = data.get("tid") or "IOC"
+            text_truncated = data.get("text", "").replace("\n", "")[:10]
+            entry_str = f"{mapping_key} - {text_truncated}"
+
+            tile_id = self._generate_tile_id(entry_str)
+            if not tile_id:
+                continue
+
+            added = False
+
+            if data_type == IOC:
+                added = self._add_ioc_object(tile_id, data)
+
+            elif data_type == TTP:
+                if mapping_key.startswith("T"):
+                    added = self._add_ttp_object(tile_id, data)
+
+                elif mapping_key.startswith("S"):
+                    added = self._add_malware_object(tile_id, data)
+
+            if added:
+                self._add_tile_to_layout(tile_id)
+
+        self._finalise_objects_list()
+
+    def _set_name_and_description(self):
+        """Sets the name and description to be exported."""
+        if len(self.report_title) >= NAME_CHAR_LIMIT:
+            self.name = f"{self.report_title[: NAME_CHAR_LIMIT - 1]}-"
+            self.description = self.report_title
+
+        else:
+            self.name = self.report_title
+
+    def _finalise_description(self):
+        """Finalises the description to include any errors that occurred during export."""
+        error_str = "\n".join(self.errors)
+
+        if error_str:
+            self.description = f"{self.description}\n\n" if self.description else ""
+            self.description += error_str
+
+    def _finalise_objects_list(self):
+        """Finalises the objects-list to be exported."""
+        flow_entry = self._generate_flow_object()
+        self.exported["objects"] = [flow_entry] + self.objects
+
+    def _add_layout_object(self):
+        """Adds the layout-entry to the exported data."""
+        self.exported["layout"] = self.layout
+
+    def _add_camera_object(self):
+        """Adds the camera-entry to the exported data."""
+        self.exported["camera"] = {
+            "x": START_X + TILE_SHIFT,
+            "y": START_Y + TILE_SHIFT,
+            "k": 0.5,
+        }
+
+    def _generate_flow_object(self):
+        """Generates and returns the flow-entry to be added to the exported data."""
+        self._finalise_description()
+
+        return {
+            "id": "flow",
+            "properties": [
+                ["name", self.name],
+                ["description", self.description],
+                [
+                    "author",
+                    [
+                        ["name", None],
+                        ["identity_class", "individual"],
+                    ],
+                ],
+                ["scope", "attack-tree"],
+                ["created", datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")],
+            ],
+            "objects": list(self.current_ids),
+        }
+
+    def _add_ioc_object(self, tile_id, data):
+        """Adds the IoC-entry to the objects-list."""
+        try:
+            return self._add_ip_object(tile_id, data)
+
+        except ValueError:
+            return self._add_command_line_object(tile_id, data)
+
+    def _add_ip_object(self, tile_id, data):
+        """Adds the IP-entry to the objects-list."""
+        ioc_cleaned_text = data.get("refanged_text", "")
+        ioc_text = data.get("text", "")
+
+        ip_obj = ip_address(ioc_cleaned_text)
+        tile_type = None
+
+        if isinstance(ip_obj, IPv4Address):
+            tile_type = "ipv4_addr"
+        elif isinstance(ip_obj, IPv6Address):
+            tile_type = "ipv6_addr"
+
+        if tile_type:
+            self._add_object(
+                tile_id,
+                tile_type,
+                properties=[
+                    ["value", ioc_text],
+                ],
+            )
+            return True
+
+    def _add_command_line_object(self, tile_id, data):
+        """Adds the command-line-entry to the objects-list."""
+        executed = data.get("text", "")
+
+        self._add_object(
+            tile_id,
+            "process",
+            properties=[
+                ["command_line", executed],
+            ],
+        )
+        return True
+
+    def _add_ttp_object(self, tile_id, data):
+        """Adds the TTP-entry to the objects-list."""
+        tech_name = data.get("name")
+        tech_tid = data.get("tid")
+        tech_uid = data.get("attack_uid")
+
+        self._add_object(
+            tile_id,
+            "action",
+            properties=[
+                ["name", tech_name],
+                ["technique_id", tech_tid],
+                ["technique_ref", tech_uid],
+                [
+                    "ttp",
+                    [
+                        ["technique", tech_tid],
+                    ],
+                ],
+            ],
+        )
+
+        return True
+
+    def _add_malware_object(self, tile_id, data):
+        """Adds the malware-entry to the objects-list."""
+        malware_name = data.get("name")
+
+        self._add_object(
+            tile_id,
+            "malware",
+            properties=[
+                ["name", malware_name],
+            ],
+        )
+        return True
+
+    def _add_object(self, tile_id, id_val, properties=None):
+        """Adds an-entry to the objects-list."""
+        properties = properties or []
+
+        self.objects.append(
+            {
+                "id": id_val,
+                "instance": tile_id,
+                "properties": properties,
+                "anchors": {},
+            }
+        )
+
+    def _add_tile_to_layout(self, tile_id):
+        """Updates the layout object to place the given tile_id."""
+        self.layout[tile_id] = [self.current_x, self.current_y]
+        self._update_current_position()
+
+    def _update_current_position(self):
+        """Updates the current position in the layout."""
+        self.current_x += TILE_SHIFT
+
+        if self.current_x > (TILE_SHIFT * TILES_PER_ROW):
+            self.current_x = 0
+            self.current_y += TILE_SHIFT
+
+    def _generate_tile_id(self, log_missing):
+        """Generates and returns a new ID."""
+        for _ in range(5):
+            new_id = str(uuid4())
+
+            if new_id not in self.current_ids:
+                self.current_ids.add(new_id)
+                return new_id
+
+        self.errors.append(f"Missing {log_missing}")

--- a/threadcomponents/reports/afb_exporter.py
+++ b/threadcomponents/reports/afb_exporter.py
@@ -1,0 +1,10 @@
+class AFBExporter:
+    """A class to export report mappings in an AFB format."""
+    def __init__(self):
+        pass
+
+    async def export(self):
+        """Executes the export."""
+        data = {}
+
+        return data

--- a/threadcomponents/reports/report_exporter.py
+++ b/threadcomponents/reports/report_exporter.py
@@ -59,8 +59,14 @@ class ReportExporter:
 
     async def afb_export(self, request):
         """Exports a report in an AFB format."""
-        data = await AFBExporter().export()
-        return json.dumps(data, indent=4)
+        report = await self.check_request_for_export(request, "afb-export")
+        report_id = report[UID]
+        report_title = report[TITLE]
+        techniques = await self.data_svc.get_confirmed_techniques_for_afb_export(report_id)
+
+        data = AFBExporter(report_title, techniques).export()
+        filename = f"{sanitise_filename(report_title)}.afb"
+        return filename, json.dumps(data, indent=4)
 
     async def nav_export(self, request):
         """Exports a report in a navigator-friendly format."""

--- a/threadcomponents/service/web_svc.py
+++ b/threadcomponents/service/web_svc.py
@@ -21,7 +21,7 @@ BLOCKED_IMG_TYPES = {"gif", "apng", "webp", "avif", "mng", "flif"}
 class WebService:
     # Static class variables for the keys in app_routes
     HOME_KEY, COOKIE_KEY, EDIT_KEY, ABOUT_KEY, REST_KEY = "home", "cookies", "edit", "about", "rest"
-    EXPORT_PDF_KEY, EXPORT_NAV_KEY, STATIC_KEY = "export_pdf", "export_nav", "static"
+    EXPORT_PDF_KEY, EXPORT_NAV_KEY, EXPORT_AFB_KEY, STATIC_KEY = "export_pdf", "export_nav", "export_afb", "static"
     HOW_IT_WORKS_KEY, WHAT_TO_SUBMIT_KEY = "how_it_works", "what_to_submit"
     REPORT_PARAM = "file"
     # Variations of punctuation we want to note
@@ -88,6 +88,7 @@ class WebService:
             self.REST_KEY: route_prefix + "/rest",
             self.EXPORT_PDF_KEY: route_prefix + "/export/pdf/{%s}" % self.REPORT_PARAM,
             self.EXPORT_NAV_KEY: route_prefix + "/export/nav/{%s}" % self.REPORT_PARAM,
+            self.EXPORT_AFB_KEY: route_prefix + "/export/afb/{%s}" % self.REPORT_PARAM,
             self.HOW_IT_WORKS_KEY: route_prefix + "/how-thread-works",
             self.STATIC_KEY: route_prefix + "/theme/",
         }

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -48,12 +48,13 @@
   <div class="col-md-auto">
     <button onclick="$.getJSON('{{pdf_link}}', (x) => {downloadPDF(x);})" class="btn btn-primary">Export PDF</button>
   </div>
+
   <div class="col-md-auto">
-    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export Navigator JSON</button>
-    <div class="dropdown-menu bg-dark" id="dropdownMenu" aria-labelledby="dropdownMenuButton">
-      <h6 class="dropdown-header">Enterprise Layer</h6>
-      <a class="dropdown-item text-white" onclick="$.getJSON('{{nav_link}}', (x) => {downloadLayer(x);})">download</a>
-    </div>
+    <a href="{{nav_link}}" class="btn btn-primary" download>Export Navigator JSON</a>
+  </div>
+
+  <div class="col-md-auto">
+    <a href="{{afb_link}}" class="btn btn-primary" download>Export AFB</a>
   </div>
 </div>
 

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -681,32 +681,6 @@ function downloadPDF(data) {
   generatedPDF.download(data["info"]["title"]);
 }
 
-function downloadLayer(data) {
-  // Create the name of the JSON download file from the name of the report
-  var json = JSON.parse(data)
-  var filename = json["filename"] + ".json";
-  // We don't need to include the filename property within the file
-  delete json["filename"];
-  // Encode updated json as a uri component
-  var dataStr = "text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(json));
-  // Create temporary DOM element with attribute values needed to perform the download
-  var a = document.createElement("a");
-  a.href = "data:" + dataStr;
-  a.download = filename;
-  a.innerHTML = "download JSON";
-  // Add the temporary element to the DOM
-  var container = document.getElementById("dropdownMenu");
-  container.appendChild(a);
-  // Download the JSON document
-  a.click();
-  // Remove the temporary element from the DOM
-  a.remove();
-}
-
-function viewLayer(data) {
-  console.info("viewLayer: " + data)
-}
-
 function divSentenceReload() {
   $("#sentenceContextSection").load(document.URL +  " #sentenceContextSection");
 }


### PR DESCRIPTION
Adds an export button to edit-report pages to produce an .afb file compatible with Attack Flow.

Navigator-JSON response is also set to be downloadable from the server-side. (PDF export not done as the client-side uses pdfmake for final steps.)